### PR TITLE
Switch to internal endpoints everywhere

### DIFF
--- a/stacklight_tests/clients/fixtures.py
+++ b/stacklight_tests/clients/fixtures.py
@@ -98,7 +98,7 @@ def kibana_client(elasticsearch_config):
 
 @pytest.fixture(scope="session")
 def os_clients(keystone_config):
-    auth_url = "http://{}:5000/".format(keystone_config["public_address"])
+    auth_url = "http://{}:5000/".format(keystone_config["private_address"])
     openstack_clients = client_manager.OfficialClientManager(
         username=keystone_config["admin_name"],
         password=keystone_config["admin_password"],

--- a/stacklight_tests/clients/openstack/client_manager.py
+++ b/stacklight_tests/clients/openstack/client_manager.py
@@ -10,6 +10,7 @@ from novaclient import client as novaclient
 from stacklight_tests import file_cache
 from stacklight_tests import settings
 from stacklight_tests import utils
+import os
 
 
 class OfficialClientManager(object):
@@ -23,9 +24,12 @@ class OfficialClientManager(object):
     KEYSTONECLIENT_VERSION = 2, 0
     NEUTRONCLIENT_VERSION = 2
     NOVACLIENT_VERSION = 2
+    INTERFACE = 'admin'
+    if "OS_ENDPOINT_TYPE" in os.environ.keys():
+        INTERFACE = os.environ["OS_ENDPOINT_TYPE"]
 
     def __init__(self, username=None, password=None,
-                 tenant_name=None, auth_url=None, endpoint_type="publicURL",
+                 tenant_name=None, auth_url=None, endpoint_type="internalURL",
                  cert=False, domain="Default", **kwargs):
         self.traceback = ""
 
@@ -122,7 +126,8 @@ class OfficialClientManager(object):
             auth_url=auth_url, cert=cert, domain=domain)
         service_type = 'network'
         return neutron_client.Client(
-            service_type=service_type, session=session, **kwargs)
+            service_type=service_type, session=session,
+            interface=cls.INTERFACE, **kwargs)
 
     @classmethod
     def get_volume_client(cls, username=None, password=None,
@@ -135,6 +140,7 @@ class OfficialClientManager(object):
         return cinder_client.Client(
             version=cls.CINDERCLIENT_VERSION,
             service_type=service_type,
+            interface=cls.INTERFACE,
             session=session, **kwargs)
 
     @classmethod
@@ -148,6 +154,7 @@ class OfficialClientManager(object):
         return glance_client.Client(
             version=cls.GLANCECLIENT_VERSION,
             service_type=service_type,
+            interface=cls.INTERFACE,
             session=session, **kwargs)
 
     @classmethod
@@ -162,6 +169,7 @@ class OfficialClientManager(object):
         return heat_client.Client(
             version=cls.HEATCLIENT_VERSION,
             service_type=service_type,
+            interface=cls.INTERFACE,
             session=session, **kwargs)
 
     @property


### PR DESCRIPTION
Let's switch to internal endpoints everywhere. Sometimes publicURL are not fully configured (e.g. no certificates), so we will avoid the situation when tests fail because of wrong configuration of Openstack. 